### PR TITLE
Fix crash upon relative imports without module name

### DIFF
--- a/flake8_typing_collections/ast_import_decode.py
+++ b/flake8_typing_collections/ast_import_decode.py
@@ -150,7 +150,10 @@ def _analyze(statements: Sequence[ast.AST]) -> Dict[str, str]:
                     potential_aliases[alias.asname].append(alias.name)
         elif isinstance(statement, ast.ImportFrom):
             for alias in statement.names:
-                fullname = ("." * statement.level) + statement.module + "." + alias.name
+                if statement.module is not None:
+                    fullname = ("." * statement.level) + statement.module + "." + alias.name
+                else:
+                    fullname = ("." * statement.level) + alias.name
                 if alias.asname is None:
                     potential_aliases[alias.name].append(fullname)
                 else:

--- a/tests/test_ast_import_decode.py
+++ b/tests/test_ast_import_decode.py
@@ -161,19 +161,24 @@ def test_assignment():
 CODE_RELATIVE_IMPORTS = """
 from .foo import X
 from ..bar import Y
+from . import Z
 X
 Y
+Z
 """
 
 
 def test_relative_imports():
     tree = ast.parse(CODE_RELATIVE_IMPORTS)
-    node1 = tree.body[2].value
-    node2 = tree.body[3].value
+    node1 = tree.body[3].value
+    node2 = tree.body[4].value
+    node3 = tree.body[5].value
     name1 = decode(tree, node1)
     name2 = decode(tree, node2)
+    name3 = decode(tree, node3)
     assert name1 == ".foo.X"
     assert name2 == "..bar.Y"
+    assert name3 == ".Z"
 
 
 CODE_NONTRIVIAL_ASSIGN = """


### PR DESCRIPTION
Using relative from-import statements of the form `from . import a` or `from .. import a` in the code under check crashes the plugin (and flake8 with it). This is fixed (and tested) by the changes in this PR.